### PR TITLE
Fix bulk enroll button URL in course admin template

### DIFF
--- a/backend/scheduler/templates/admin/scheduler/course/change_list.html
+++ b/backend/scheduler/templates/admin/scheduler/course/change_list.html
@@ -9,5 +9,10 @@
         </a>
     </li>
     {% endif %}
+    <li>
+        <a href="{% url 'admin:course_bulk_enroll' %}" class="btn btn-high">
+            {% trans "Bulk Enroll Students" %}
+        </a>
+    </li>
     {{ block.super }}
 {% endblock %} 


### PR DESCRIPTION
Fixed the URL pattern in the course admin template to correctly link to the bulk enrollment view. Changed from 'admin:scheduler_course_bulk_enroll' to 'admin:course_bulk_enroll' to match the URL name defined in CourseAdmin class.